### PR TITLE
fix(design-systems): fix spelling mistakes

### DIFF
--- a/content/pages/1--design-systems/index.md
+++ b/content/pages/1--design-systems/index.md
@@ -25,7 +25,7 @@ the public artifacts of my design-systems activity.
 
 * [Hands-on with Design Systems](/design-systems/hands-on-workshop/)<br/>
 Full-day workshop about building design system and pattern library (React) in multidisciplinary team. This workshop was
-given twice - as a part of DFConf Helsini, and the second time on its own.
+given twice - as a part of DSConf Helsinki, and the second time on its own.
 
 * [How to build a Design System as a team](/design-systems/team-process-workshop/)<br/>
 Half-day workshop for teams and individuals interested in managing design system teams and running smooth processes for
@@ -98,7 +98,7 @@ At Yandex, I worked in BEM team on [methodology, technologies, libraries and a t
 
 * Shaping the concept of BEM as methodology.
 * Developing open source libraries of components.
-* Providing documemntation for the methodology, technologies, tools and libraries.
+* Providing documentation for the methodology, technologies, tools and libraries.
 * Public speaking and writing articles about the project items.
 
 ### Lego project by Yandex

--- a/content/pages/1--design-systems/index.md
+++ b/content/pages/1--design-systems/index.md
@@ -83,7 +83,7 @@ particular, this meant aligning the strategy of the design system project togeth
 inner user researches, develop detailed project plans and managing their implementing. Altogether, the achievements of
 the project were:
 
-* Clear strategy and developed year, quoter and monthly plans for the design system projects.
+* Clear strategy and developed an yearly, quarter and monthly plans for the design system projects.
 * Constant work with in-house design and development community.
 * Implementing in-house open source model for maintaining the design system projects.
 * Organizing effective but simple project management practices and routines.


### PR DESCRIPTION
- Fix typo `DFConf Helsini` to `DSConf Helsinki`
- Fix typo `documemntation` to `documentation`
- Fix typo `year` to `an yearly`
- Fix typo `quoter` to `quarter`
