### PR TITLE
Fixed missing images in posts

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,7 +30,6 @@ module.exports = {
           projects: path.resolve("./src/templates/ProjectPost.js"),
         },
         gatsbyRemarkPlugins: [
-          "gatsby-remark-unwrap-images",
           {
             resolve: `gatsby-remark-images`,
             options: {


### PR DESCRIPTION
I noticed that all the images from blog posts are missing. This change fixes. `gatsby-remark-unwrap-images` is still in use but in another place. Could you check that everything is working?