### PR TITLE
Fix zero-height images in blog

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -36,6 +36,7 @@ module.exports = {
             options: {
               maxWidth: 1600,
               backgroundColor: "transparent",
+              wrapperStyle: "width: 100%;",
             },
           },
           `gatsby-remark-prismjs`,


### PR DESCRIPTION
It's an alternative fix for #150. I propose to use this, because #150 disables gatsby-unwrap-images plugin. 
And we need this plugin, because our custom Image component, should not be wrapped with <p> tags - it cause the HTML validation errors - <figure> inside <p> is not allowed.
