### PR TITLE
Frontmatter/link

### DIFF
--- a/content/projects/hands-on-with-design-systems-2021.md
+++ b/content/projects/hands-on-with-design-systems-2021.md
@@ -1,0 +1,7 @@
+---
+title: Hands-on with Design Systems (2021)
+date: 2021-04-08
+description: >
+  A remote workshop for designers and developers for learning and practicing design systems, working in a team. During this workshop, the participants got hands-on experience with basic design processes while creating and maintaining their own design system.
+link: https://hands-on-workshop.varya.me/
+---

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -151,6 +151,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
               title
               subTitle
               date
+              link
             }
           }
         }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -124,6 +124,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
             frontmatter {
               title
               subTitle
+              link
               v2
               old
               date

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -36,8 +36,9 @@ const Projects = ({ data }) => {
     >
       <WidgetContainer items={{ small: 1, medium: 2, large: 2 }}>
         {posts.map((post, index) => {
-          const { title } = post.node.frontmatter;
+          const { title, link } = post.node.frontmatter;
           const { slug } = post.node.fields;
+          const resolvedSlug = link ? link : `/${slug}`;
           const excerpt =
             post.node.frontmatter.description || post.node.excerpt;
           const background = colors[index % 3];
@@ -45,7 +46,7 @@ const Projects = ({ data }) => {
             <Widget
               key={title}
               title={title}
-              slug={`/${slug}`}
+              slug={resolvedSlug}
               excerpt={excerpt}
               background={background}
             />
@@ -79,6 +80,7 @@ export const projectsQuery = graphql`
             title
             date(formatString: "DD MMMM YYYY")
             description
+            link
             meta {
               desc
             }

--- a/src/templates/BlogIndex.js
+++ b/src/templates/BlogIndex.js
@@ -46,15 +46,15 @@ const Blog = ({ data, pageContext }) => {
         >
           <WidgetContainer>
             {posts.map((post) => {
-              const cover = post.node.frontmatter.cover;
-              const date = post.node.frontmatter.date;
-              const readingTime = post.node.fields.readingTime;
+              const { cover, date, link } = post.node.frontmatter;
+              const { readingTime, slug } = post.node.fields;
+              const resolvedSlug = link ? link : `/${slug}`;
               return (
                 <Widget
                   key={post.node.frontmatter.title}
                   image={cover && <Img {...cover.childImageSharp} />}
                   title={post.node.frontmatter.title}
-                  slug={`/${post.node.fields.slug}`}
+                  slug={resolvedSlug}
                   excerpt={post.node.excerpt}
                   height="small"
                   date={date}
@@ -110,6 +110,7 @@ export const blogQuery = graphql`
           }
           frontmatter {
             title
+            link
             date(formatString: "DD MMMM YYYY")
             cover {
               childImageSharp {


### PR DESCRIPTION
Added link option to frontmatter.
Usage: 

```mdx
link: http://yandex.ru
```

If this prop present, slug prop is ignored, and widget component will use the provided link.

PS. I named the last workshop (2021) - just thought it looks better, but let me know if you prefer to rename titles as "online" and "offline"